### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [![PyPI](https://img.shields.io/pypi/v/mcp-bigquery.svg)](https://pypi.org/project/mcp-bigquery/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dd/mcp-bigquery)
 
+<a href="https://glama.ai/mcp/servers/@caron14/mcp-bigquery">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@caron14/mcp-bigquery/badge" alt="BigQuery Validator MCP server" />
+</a>
+
 The `mcp-bigquery` package provides a minimal MCP server for BigQuery SQL validation and dry-run analysis. This server provides exactly two tools for validating and analyzing BigQuery SQL queries without executing them.
 
 ** IMPORTANT: This server does NOT execute queries. All operations are dry-run only. Cost estimates are approximations based on bytes processed.**


### PR DESCRIPTION
This PR adds a badge for the [BigQuery Validator](https://glama.ai/mcp/servers/@caron14/mcp-bigquery) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@caron14/mcp-bigquery">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@caron14/mcp-bigquery/badge" alt="BigQuery Validator MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.