### PR TITLE
Patch/v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,66 +12,64 @@
 [![Downloads](https://img.shields.io/pypi/dd/mcp-bigquery)](https://pypi.org/project/mcp-bigquery/)
 
 [**Documentation**](https://caron14.github.io/mcp-bigquery/) | 
-[**Quick Start**](#-quick-start-4-minutes) | 
-[**Tools**](#-available-tools) | 
-[**Examples**](#-real-world-examples)
+[**Quick Start**](#-quick-start) | 
+[**Examples**](#-examples-of-usage)
 
 </div>
 
 ---
 
-## 📌 What is this?
+## Overview
 
-**mcp-bigquery** is an MCP (Model Context Protocol) server that enables AI assistants like Claude to **safely** interact with Google BigQuery.
+mcp-bigquery is a Model Context Protocol (MCP) server that enables AI assistants (such as Claude) to interact securely with Google BigQuery.
 
-### 🎯 Key Features
+### Key Features
 
-```mermaid
-graph LR
-    A[AI Assistant] -->|MCP Protocol| B[mcp-bigquery]
-    B -->|Dry-run Only| C[BigQuery API]
-    B -.->|❌ Never Executes| D[Actual Query Execution]
-```
+* **Secure execution**: All operations are strictly limited to dry-run verification. The server never executes queries that mutate data or incur execution costs.
+* **Cost transparency**: Provides estimates of query costs and processed bytes before execution.
+* **Static analysis**: Analyzes query dependencies and validates SQL syntax.
+* **Schema exploration**: Browses datasets, tables, and columns.
 
-- **🛡️ 100% Safe**: All operations are dry-run only (never executes queries)
-- **💰 Cost Transparency**: See costs before running any query
-- **🔍 Complete Analysis**: Analyze dependencies and validate SQL syntax
-- **📊 Schema Explorer**: Browse datasets, tables, and columns with ease
-
-### ⚡ Why use mcp-bigquery?
+### Business Value
 
 | Problem | Solution with mcp-bigquery |
 |---------|---------------------------|
-| 💸 Accidentally running expensive queries | Check costs before execution |
-| 🐛 Wasting time on SQL errors | Detect syntax errors before running |
-| 🗺️ Unknown table structures | Easily explore schemas |
-| ⚠️ AI executing dangerous operations | Everything is read-only and safe |
+| Unintentional execution of costly queries | Pre-execution cost estimation |
+| Delayed development due to SQL syntax errors | Early syntax error detection |
+| Lack of visibility into schema structures | Secure schema metadata discovery |
+| Risk of unauthorized data mutation by AI | Enforced dry-run constraints |
 
-## 🚀 Quick Start (4 minutes)
+---
 
-### Step 1: Install (1 minute)
+## Quick Start
+
+### Step 1: Installation
+
+Install the package via pip:
 
 ```bash
 pip install mcp-bigquery
 ```
 
-### Step 2: Authenticate with Google Cloud (2 minutes)
+### Step 2: Authentication
+
+Set up Google Cloud Platform authentication:
 
 ```bash
-# For personal accounts
+# For user account authentication
 gcloud auth application-default login
 
-# For service accounts
+# For service account authentication
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
 ```
 
-### Step 3: Configure Claude Desktop (1 minute)
+### Step 3: Claude Desktop Configuration
 
-Open your Claude Desktop config:
-- **Mac**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+Configure the server in the Claude Desktop configuration file:
+* **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+* **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
-Add this configuration:
+Add the following entry:
 
 ```json
 {
@@ -79,49 +77,127 @@ Add this configuration:
     "mcp-bigquery": {
       "command": "mcp-bigquery",
       "env": {
-        "BQ_PROJECT": "your-gcp-project-id"  // ← Replace with your project ID
+        "BQ_PROJECT": "your-gcp-project-id"
       }
     }
   }
 }
 ```
 
-### Step 4: Test It!
+### Step 4: Verification
 
-Restart Claude Desktop and try these questions:
+Restart Claude Desktop and run the following queries to verify the setup:
 
-```
-"What datasets are available in my BigQuery project?"
-"Can you estimate the cost of: SELECT * FROM dataset.table"
-"Show me the schema for the users table"
-```
+* "What datasets are available in my BigQuery project?"
+* "Can you estimate the cost of: SELECT * FROM dataset.table"
+* "Show me the schema for the users table"
 
-## 🛠️ Available Tools
+---
 
-### 📝 SQL Validation & Analysis
+## Available Tools
 
-| Tool | Purpose | When to Use |
-|------|---------|-------------|
-| **bq_validate_sql** | Check SQL syntax | Before running any query |
-| **bq_dry_run_sql** | Get cost estimates & metadata | 💰 To check costs |
-| **bq_extract_dependencies** | Extract table dependencies | To understand data lineage |
-| **bq_validate_query_syntax** | Detailed error analysis | To debug SQL errors |
+### SQL Validation and Analysis
 
-### 🔍 Schema Discovery
+| Tool | Purpose | Primary Use Case |
+|------|---------|------------------|
+| **bq_validate_sql** | Check SQL syntax | Verification prior to query execution |
+| **bq_dry_run_sql** | Retrieve cost estimates and metadata | Pre-execution cost assessment |
+| **bq_extract_dependencies** | Map table dependencies | Lineage and dependency mapping |
+| **bq_validate_query_syntax** | Detailed syntax analysis | Debugging complex SQL queries |
 
-| Tool | Purpose | When to Use |
-|------|---------|-------------|
-| **bq_list_datasets** | List all datasets | To explore your project |
-| **bq_list_tables** | List tables with partitioning info | To browse a dataset |
-| **bq_describe_table** | Get detailed table schema | To understand columns |
-| **bq_get_table_info** | Complete table metadata | To get statistics |
-| **bq_preview_table** | Preview table data (cost-free) | To view sample records without scan costs |
+### Schema Discovery
+
+| Tool | Purpose | Primary Use Case |
+|------|---------|------------------|
+| **bq_list_datasets** | List all datasets in the project | Initial project discovery |
+| **bq_list_tables** | List tables with partitioning metadata | Dataset structure browsing |
+| **bq_describe_table** | Get detailed schema details | Column-level verification |
+| **bq_get_table_info** | Retrieve comprehensive metadata | Table statistics analysis |
+| **bq_preview_table** | Preview table data (cost-free) | Checking sample records without data scan costs |
 
 > [!IMPORTANT]
-> **bq_preview_table** uses `client.list_rows` (API: `tabledata.list`) to retrieve sample rows directly without running a query job, keeping it **cost-free (0 bytes billed)**. To prevent accidental data exposure of sensitive information (PII) to the LLM, this tool is **disabled by default**. You must explicitly opt-in by setting `MCP_BQ_ENABLE_PREVIEW=true` in your environment.
+> The **bq_preview_table** tool uses `client.list_rows` (API: `tabledata.list`) to retrieve sample rows directly, resulting in zero bytes scanned and no execution costs. To prevent unintended exposure of sensitive information (such as PII) to the LLM, this tool is disabled by default. You must explicitly opt in by setting `MCP_BQ_ENABLE_PREVIEW=true` in your environment config.
 
+---
 
-## 💡 Real-World Examples
+## Configuration
+
+### Environment Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `BQ_PROJECT` | Target GCP Project ID | Determined via ADC |
+| `BQ_LOCATION` | Target BigQuery Region | Not set |
+| `SAFE_PRICE_PER_TIB` | Price per TiB for cost estimation | 5.0 |
+| `LOG_LEVEL` | Logging verbosity (DEBUG, INFO, WARNING, ERROR, CRITICAL) | WARNING |
+| `MCP_BQ_ENABLE_PREVIEW` | Enable the bq_preview_table tool (true/false) | false |
+
+### Example .env File
+
+For local testing or development environments, you can define these variables in a `.env` file:
+
+```env
+BQ_PROJECT=your-gcp-project-id
+BQ_LOCATION=asia-northeast1
+SAFE_PRICE_PER_TIB=5.0
+LOG_LEVEL=WARNING
+MCP_BQ_ENABLE_PREVIEW=true
+```
+
+### Complete Claude Desktop Configuration Example
+
+```json
+{
+  "mcpServers": {
+    "mcp-bigquery": {
+      "command": "mcp-bigquery",
+      "env": {
+        "BQ_PROJECT": "my-production-project",
+        "BQ_LOCATION": "asia-northeast1",
+        "SAFE_PRICE_PER_TIB": "6.0",
+        "LOG_LEVEL": "WARNING",
+        "MCP_BQ_ENABLE_PREVIEW": "true"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Troubleshooting
+
+### Mapped Errors and Solutions
+
+#### Authentication Error
+```
+Error: Could not automatically determine credentials
+```
+* **Solution**: Re-authenticate using the command line:
+  ```bash
+  gcloud auth application-default login
+  ```
+
+#### Permission Denied
+```
+Error: User does not have bigquery.tables.get permission
+```
+* **Solution**: Grant the `BigQuery Data Viewer` role to the target identity:
+  ```bash
+  gcloud projects add-iam-policy-binding YOUR_PROJECT \
+    --member="user:your-email@example.com" \
+    --role="roles/bigquery.dataViewer"
+  ```
+
+#### Project ID Missing
+```
+Error: Project ID is required
+```
+* **Solution**: Ensure the `BQ_PROJECT` variable is set correctly in your configuration.
+
+---
+
+## Examples of Usage
 
 ### Example 1: Check Costs Before Running
 
@@ -182,151 +258,41 @@ result = bq_extract_dependencies(sql=query)
 #   users → final_result
 ```
 
-## 🎨 How It Works
+---
 
-```
-Your Code ← → Claude/AI Assistant
-                   ↓
-            MCP Protocol
-                   ↓
-            mcp-bigquery
-                   ↓
-         BigQuery API (Dry-run)
-                   ↓
-             BigQuery
-      (Never executes actual queries)
-```
+## Project Status and Version History
 
-## ⚙️ Configuration
-
-### Environment Variables
-
-```bash
-export BQ_PROJECT="my-project"        # GCP Project ID (required)
-export BQ_LOCATION="asia-northeast1"  # Region (optional)
-export SAFE_PRICE_PER_TIB="5.0"      # Price per TiB (default: $5)
-export LOG_LEVEL="INFO"              # Optional log level override
-export MCP_BQ_ENABLE_PREVIEW="true"  # Opt-in to enable bq_preview_table (default: false)
-```
-
-### Full Claude Desktop Configuration
-
-```json
-{
-  "mcpServers": {
-    "mcp-bigquery": {
-      "command": "mcp-bigquery",
-      "env": {
-        "BQ_PROJECT": "my-production-project",
-        "BQ_LOCATION": "asia-northeast1",
-        "SAFE_PRICE_PER_TIB": "6.0",
-        "LOG_LEVEL": "WARNING",
-        "MCP_BQ_ENABLE_PREVIEW": "true"
-      }
-    }
-  }
-}
-```
-
-## 🔧 Troubleshooting
-
-### Common Issues & Solutions
-
-#### ❌ Authentication Error
-```
-Error: Could not automatically determine credentials
-```
-**Solution:**
-```bash
-gcloud auth application-default login
-```
-
-#### ❌ Permission Error
-```
-Error: User does not have bigquery.tables.get permission
-```
-**Solution:** Grant BigQuery Data Viewer role
-```bash
-gcloud projects add-iam-policy-binding YOUR_PROJECT \
-  --member="user:your-email@example.com" \
-  --role="roles/bigquery.dataViewer"
-```
-
-#### ❌ Project Not Set
-```
-Error: Project ID is required
-```
-**Solution:** Set `BQ_PROJECT` in your configuration
-
-### Debug Mode
-
-If issues persist, enable debug mode:
-
-```json
-{
-  "env": {
-    "LOG_LEVEL": "INFO",
-    "BQ_PROJECT": "your-project"
-  }
-}
-```
-
-## 📚 Learn More
-
-### Getting Started
-- [Installation Guide](https://caron14.github.io/mcp-bigquery/installation/)
-- [Usage Guide](https://caron14.github.io/mcp-bigquery/usage/)
-
-### For Developers
-- [Local Development](https://caron14.github.io/mcp-bigquery/development/)
-- [Contributing Guide](CONTRIBUTING.md)
-
-## 🚦 Project Status
-
-| Version | Release Date | Key Features |
-|---------|--------------|--------------|
-| v0.7.0 | 2026-06-21 | Cost-free table preview tool (`bq_preview_table`) and security opt-in |
-| v0.6.0 | 2026-06-21 | Thread-safe caching, recursive AST queries, backoff retries, mapping exceptions |
-| v0.5.0 | 2026-01-02 | Consolidated formatters, client cache, logging controls |
-| v0.4.2 | 2025-12-08 | Modular schema explorer, unified client/logging controls |
-| v0.4.1 | 2025-01-22 | Better error handling, debug logging |
-| v0.4.0 | 2025-01-22 | Added 6 schema discovery tools |
-| v0.3.0 | 2025-01-17 | SQL analysis engine |
-| v0.2.0 | 2025-01-16 | Basic validation & dry-run |
-
-
-## 🤝 Contributing
-
-Pull requests are welcome! See our [Contributing Guide](CONTRIBUTING.md).
-
-```bash
-# Setup development environment
-git clone https://github.com/caron14/mcp-bigquery.git
-cd mcp-bigquery
-pip install -e ".[dev]"
-
-# Run tests
-pytest tests/
-```
-
-## 📄 License
-
-MIT License - see [LICENSE](LICENSE) for details.
-
-## 🙏 Acknowledgments
-
-- Google BigQuery team for the excellent API
-- Anthropic for the MCP protocol
-- All contributors and users
+| Version | Release Date | Summary of Changes |
+|---------|--------------|--------------------|
+| v0.7.0 | 2026-06-21 | Added cost-free table preview tool (`bq_preview_table`) and security opt-in configuration |
+| v0.6.0 | 2026-06-21 | Thread-safe caching, recursive AST queries, backoff retries, and Google API exception mapping |
+| v0.5.0 | 2026-01-02 | Consolidated formatters, client cache, and unified logging controls |
+| v0.4.2 | 2025-12-08 | Modular schema explorer and unified client/logging controls |
+| v0.4.1 | 2025-01-22 | Error handling and debug logging improvements |
+| v0.4.0 | 2025-01-22 | Added schema discovery tools |
+| v0.3.0 | 2025-01-17 | Integrated SQL static analysis engine |
+| v0.2.0 | 2025-01-16 | Initial release supporting basic validation and dry-run queries |
 
 ---
 
-<div align="center">
+## Development and Contribution
 
-**Built for safe BigQuery exploration** 🛡️
+For instructions on local development setup and contribution policies, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
 
-[Report Bug](https://github.com/caron14/mcp-bigquery/issues) · 
-[Request Feature](https://github.com/caron14/mcp-bigquery/issues) · 
-[Discussions](https://github.com/caron14/mcp-bigquery/discussions)
+```bash
+# Clone the repository
+git clone https://github.com/caron14/mcp-bigquery.git
+cd mcp-bigquery
 
-</div>
+# Install development dependencies
+pip install -e ".[dev]"
+
+# Execute the test suite
+pytest tests/
+```
+
+---
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/assets/stylesheets/custom.css
+++ b/docs/assets/stylesheets/custom.css
@@ -1,0 +1,224 @@
+/* Custom CSS for MCP BigQuery Documentation */
+
+:root {
+  /* Common typography and shape transitions */
+  --md-admonition-border-radius: 12px;
+  --md-code-border-radius: 12px;
+}
+
+/* Light Theme Color Override */
+:root, [data-md-color-scheme="default"] {
+  --md-primary-fg-color: #0f172a; /* Slate 900 */
+  --md-primary-fg-color--transparent: rgba(15, 23, 42, 0.1);
+  --md-primary-bg-color: #ffffff;
+  --md-primary-bg-color--transparent: rgba(255, 255, 255, 0.7);
+  
+  --md-accent-fg-color: #0ea5e9; /* Sky 500 */
+  --md-accent-fg-color--transparent: rgba(14, 165, 233, 0.1);
+  --md-accent-bg-color: #ffffff;
+  
+  --md-default-fg-color: #334155; /* Slate 700 */
+  --md-default-bg-color: #f8fafc; /* Slate 50 */
+}
+
+/* Dark Theme Color Override */
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #090d16; /* Ultra Dark Blue */
+  --md-primary-fg-color--transparent: rgba(9, 13, 22, 0.1);
+  --md-primary-bg-color: #0f172a; /* Slate 900 */
+  --md-primary-bg-color--transparent: rgba(15, 23, 42, 0.7);
+  
+  --md-accent-fg-color: #22d3ee; /* Cyan 400 */
+  --md-accent-fg-color--transparent: rgba(34, 211, 238, 0.15);
+  --md-accent-bg-color: #0f172a;
+  
+  --md-default-fg-color: #cbd5e1; /* Slate 300 */
+  --md-default-bg-color: #0b0f19; /* Custom premium dark background */
+  
+  --md-code-bg-color: #111827; /* Rich black for code blocks */
+}
+
+/* 1. Header glassmorphism */
+.md-header {
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  transition: background-color 0.25s;
+}
+[data-md-color-scheme="default"] .md-header {
+  background-color: rgba(15, 23, 42, 0.85); /* Keep header dark even in light mode for professional contrast */
+  color: #f8fafc;
+}
+[data-md-color-scheme="slate"] .md-header {
+  background-color: rgba(9, 13, 22, 0.8);
+}
+
+/* Header Text / Logo override for light mode (because we made the header dark) */
+[data-md-color-scheme="default"] .md-header__title,
+[data-md-color-scheme="default"] .md-header__button {
+  color: #f8fafc;
+}
+[data-md-color-scheme="default"] .md-header__option input[type="radio"] + label {
+  color: #f8fafc;
+}
+
+/* 2. Global Styling & Layout */
+.md-typeset h1, 
+.md-typeset h2, 
+.md-typeset h3, 
+.md-typeset h4 {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--md-default-fg-color);
+}
+
+/* Heading Gradients for Main Titles */
+.md-typeset h1 {
+  background: linear-gradient(135deg, var(--md-accent-fg-color) 0%, #3b82f6 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  display: inline-block;
+  margin-bottom: 0.8em;
+}
+
+/* Accent lines on H2 */
+.md-typeset h2 {
+  position: relative;
+  padding-bottom: 8px;
+  border-bottom: 2px solid rgba(14, 165, 233, 0.1);
+}
+.md-typeset h2::after {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 60px;
+  height: 2px;
+  background: linear-gradient(90deg, var(--md-accent-fg-color), #3b82f6);
+}
+
+/* 3. Cards & Admonitions (Info boxes) styling */
+.md-typeset .admonition {
+  border-radius: var(--md-admonition-border-radius);
+  border-left-width: 5px;
+  box-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.md-typeset .admonition:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 30px -4px rgba(0, 0, 0, 0.08);
+}
+
+/* Custom shadow/styling for dark mode admonitions */
+[data-md-color-scheme="slate"] .md-typeset .admonition {
+  box-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.25);
+  background-color: #1e293b;
+}
+[data-md-color-scheme="slate"] .md-typeset .admonition:hover {
+  box-shadow: 0 8px 30px -4px rgba(0, 0, 0, 0.35);
+}
+
+/* 4. Code Blocks & Tabbed Views */
+.md-typeset pre {
+  border-radius: var(--md-code-border-radius);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+.md-typeset .highlight {
+  border-radius: var(--md-code-border-radius);
+  overflow: hidden;
+}
+
+/* Inline code styling */
+.md-typeset code {
+  border-radius: 6px;
+  padding: 2px 6px;
+  font-size: 0.85em;
+  background-color: rgba(14, 165, 233, 0.08);
+  color: #0284c7;
+}
+[data-md-color-scheme="slate"] .md-typeset code {
+  background-color: rgba(34, 211, 238, 0.1);
+  color: #22d3ee;
+}
+
+/* Tabs styling */
+.tabbed-set {
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.04);
+}
+[data-md-color-scheme="slate"] .tabbed-set {
+  box-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.2);
+}
+
+/* 5. Custom Button Styling */
+.md-typeset .md-button {
+  border-radius: 30px;
+  padding: 0.6em 1.6em;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.md-typeset .md-button--primary {
+  background-color: var(--md-accent-fg-color);
+  color: #fff;
+  border-color: var(--md-accent-fg-color);
+}
+.md-typeset .md-button--primary:hover {
+  background-color: #0284c7;
+  border-color: #0284c7;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(14, 165, 233, 0.3);
+}
+
+/* 6. Table styling */
+.md-typeset table:not([class]) {
+  border-radius: 12px;
+  overflow: hidden;
+  border: none;
+  box-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.03);
+}
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) {
+  box-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.2);
+  background-color: #131924;
+}
+.md-typeset table:not([class]) th {
+  background-color: rgba(14, 165, 233, 0.08);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.8em;
+  letter-spacing: 0.05em;
+  border: none;
+}
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) th {
+  background-color: rgba(34, 211, 238, 0.06);
+}
+.md-typeset table:not([class]) td {
+  border-top: 1px solid rgba(0, 0, 0, 0.03);
+  border-bottom: none;
+}
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) td {
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+/* 7. Sidebar and Navigation Styling */
+.md-nav__link {
+  border-radius: 6px;
+  transition: background-color 0.2s, color 0.2s;
+  padding: 6px 12px;
+}
+.md-nav__link:hover {
+  background-color: rgba(14, 165, 233, 0.08);
+  color: var(--md-accent-fg-color) !important;
+}
+[data-md-color-scheme="slate"] .md-nav__link:hover {
+  background-color: rgba(34, 211, 238, 0.08);
+}
+.md-nav__link--active {
+  font-weight: 700;
+  background-color: rgba(14, 165, 233, 0.12);
+  color: var(--md-accent-fg-color) !important;
+}
+[data-md-color-scheme="slate"] .md-nav__link--active {
+  background-color: rgba(34, 211, 238, 0.12);
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,7 +81,8 @@ mcp-bigquery/
 │   │   ├── __init__.py
 │   │   ├── datasets.py      # Dataset listing flows
 │   │   ├── tables.py        # Table metadata aggregation
-│   │   └── describe.py      # Schema inspection + shared formatters
+│   │   ├── describe.py      # Schema inspection + shared formatters
+│   │   └── preview.py       # Table data preview (cost-free)
 │   ├── sql_analyzer.py      # SQL analysis helpers
 │   ├── validators.py        # Input validation utilities
 │   ├── exceptions.py        # Custom exception types
@@ -297,7 +298,7 @@ setup_logging(level=level, format_json=True)
 
 The server follows MCP protocol standards:
 
-1. **Tool Registration** - Eight tools registered in `handle_list_tools()`
+1. **Tool Registration** - Nine tools registered in `handle_list_tools()`
 2. **Tool Execution** - Requests handled in `handle_call_tool()`
 3. **Error Handling** - Consistent error format across all tools
 4. **Async Support** - All operations are async for performance
@@ -317,9 +318,10 @@ The server follows MCP protocol standards:
 - SQLAnalyzer provides lightweight dependency extraction and syntax heuristics.
 - Designed for quick regex-based checks and dependency graphs.
 
-#### Schema Explorer Package (`schema_explorer/`) - updated v0.4.2
-- `datasets.py`, `tables.py`, and `describe.py` split responsibilities for dataset listing, table aggregation, and schema formatting.
+#### Schema Explorer Package (`schema_explorer/`) - updated v0.7.0
+- `datasets.py`, `tables.py`, `describe.py`, and `preview.py` split responsibilities for dataset listing, table aggregation, schema formatting, and row-level preview.
 - `describe.py` now owns shared serializers (timestamps, partitions, nested schema trees).
+- `preview.py` supports row preview with recursion and is gated by environment-level opt-in controls.
 - Modules rely on the client factory plus `validators`/`exceptions` and never import each other, preserving clean boundaries.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,14 @@
 
 ## Overview
 
-The `mcp-bigquery` package provides a comprehensive MCP server for BigQuery SQL validation, dry-run analysis, dependency analysis, and schema discovery. This server provides eight tools for validating, analyzing, and exploring BigQuery schemas without executing queries.
+The `mcp-bigquery` package provides a comprehensive MCP server for BigQuery SQL validation, dry-run analysis, dependency analysis, and schema discovery. This server provides nine tools for validating, analyzing, and exploring BigQuery schemas without executing queries.
+
+!!! info "What's new in v0.7.0"
+    - Added cost-free table preview tool (`bq_preview_table`) and security opt-in configuration.
+    - Centralised configuration via environment variables like `MCP_BQ_ENABLE_PREVIEW`.
+
+!!! info "What's new in v0.6.0"
+    - Thread-safe caching, recursive AST queries, backoff retries, and Google API exception mapping.
 
 !!! info "What's new in v0.5.0"
     - Schema explorer formatters are consolidated into `describe.py` and `tables.py`.
@@ -35,11 +42,12 @@ The `mcp-bigquery` package provides a comprehensive MCP server for BigQuery SQL 
 - **Enhanced Syntax Validation**: Detailed error reporting with suggestions
 [→ SQL Analysis Guide](usage.md#sql-analysis)
 
-### 📊 Schema Explorer & Metadata (updated v0.4.2)
+### 📊 Schema Explorer & Metadata (updated v0.7.0)
 - **Dataset Explorer**: List and explore datasets in your BigQuery project
 - **Table Browser**: Browse tables with metadata, partitioning, and clustering info via dedicated formatters
 - **Schema Inspector**: Get detailed table schemas with nested field support
 - **Comprehensive Table Info**: Access all table metadata including encryption and time travel using the new modular helpers
+- **Table Data Preview**: Preview table data cost-free without query scan billing (security opt-in required)
 [→ Schema Discovery Guide](usage.md#schema-discovery)
 
 ### 🏷️ Additional Features
@@ -119,6 +127,43 @@ The `mcp-bigquery` package provides a comprehensive MCP server for BigQuery SQL 
           "table_type": "TABLE",
           "num_rows": 164656,
           "num_bytes": 6432064
+        }
+      ]
+    }
+    ```
+
+=== "Table Data Preview"
+
+    ```json
+    {
+      "tool": "bq_preview_table",
+      "arguments": {
+        "dataset_id": "samples",
+        "table_id": "shakespeare",
+        "project_id": "bigquery-public-data",
+        "max_results": 2
+      }
+    }
+    ```
+
+    **Response:**
+    ```json
+    {
+      "dataset_id": "samples",
+      "table_id": "shakespeare",
+      "project": "bigquery-public-data",
+      "rows": [
+        {
+          "word": "thead",
+          "word_count": 2,
+          "corpus": "2kinghenryiv",
+          "corpus_date": 1598
+        },
+        {
+          "word": "remorse",
+          "word_count": 1,
+          "corpus": "2kinghenryiv",
+          "corpus_date": 1598
         }
       ]
     }

--- a/docs/module_map.md
+++ b/docs/module_map.md
@@ -1,4 +1,4 @@
-# Module Responsibility Map (v0.4.2)
+# Module Responsibility Map (v0.7.0)
 
 ## Overview
 This document lists the primary modules, their responsibilities, and notable internal dependencies to help contributors navigate the codebase.
@@ -9,6 +9,7 @@ This document lists the primary modules, their responsibilities, and notable int
 | `clients/factory.py` | 4 | 0 |
 | `schema_explorer/datasets.py` | 2 | 0 |
 | `schema_explorer/describe.py` | 2 | 0 |
+| `schema_explorer/preview.py` | 3 | 0 |
 | `schema_explorer/tables.py` | 4 | 0 |
 
 ## Core Runtime
@@ -24,7 +25,8 @@ This document lists the primary modules, their responsibilities, and notable int
 - **`mcp_bigquery.schema_explorer.datasets`** — Dataset listing workflows with centralised validation and formatting helpers.
 - **`mcp_bigquery.schema_explorer.tables`** — Table listing and detailed metadata aggregation (partitioning, clustering, constraints).
 - **`mcp_bigquery.schema_explorer.describe`** — Schema-focused describe endpoint with nested-field formatting and shared serializers.
-  - Shared dependencies: `validators`, `clients`, `exceptions`.
+- **`mcp_bigquery.schema_explorer.preview`** — Table data preview (cost-free) with environment-based safety opt-in.
+  - Shared dependencies: `validators`, `clients`, `exceptions`, `config`.
 
 ## Shared Utilities
 - **`mcp_bigquery.logging_config`** — Log level resolution, basic formatting, and a simple performance decorator.
@@ -36,4 +38,4 @@ This document lists the primary modules, their responsibilities, and notable int
 - `server` remains the sole entrypoint that touches `sql_analyzer`, minimizing cross-module coupling.
 - Logging flows through `logging_config` only; no other module calls `logging.basicConfig`, ensuring consistent stdout/stderr behaviour.
 
-Refer back to `TODO_v0.4.2.md` for outstanding chores tied to this architecture.
+Refer back to [TODO.md](file:///Users/sho/repo/mcp-bigquery/TODO.md) for outstanding chores tied to this architecture.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # Usage Guide
 
-This guide covers how to use MCP BigQuery's eight tools for SQL validation, dependency analysis, and schema discovery.
+This guide covers how to use MCP BigQuery's nine tools for SQL validation, dependency analysis, and schema discovery.
 
 ## SQL Validation
 
@@ -438,6 +438,45 @@ Access all table metadata with `bq_get_table_info`:
     "table_id": "users",
     "dataset_id": "analytics"
   }
+}
+```
+
+### Preview Table Data (v0.7.0)
+
+Get a preview of table data without running a query job with `bq_preview_table`. This tool is **completely cost-free** as it uses BigQuery's row listing API instead of scanning query data.
+
+!!! warning "Security Opt-in Required"
+    To prevent unintended exposure of sensitive data, this tool is disabled by default. You must explicitly opt in by setting the environment variable `MCP_BQ_ENABLE_PREVIEW=true` in your server environment.
+
+```json
+{
+  "tool": "bq_preview_table",
+  "arguments": {
+    "dataset_id": "analytics",
+    "table_id": "users",
+    "max_results": 5
+  }
+}
+```
+
+Response includes sample rows (maximum of 10 rows):
+```json
+{
+  "dataset_id": "analytics",
+  "table_id": "users",
+  "project": "your-project-id",
+  "rows": [
+    {
+      "user_id": 1,
+      "name": "Alice",
+      "created_at": "2024-01-01T00:00:00"
+    },
+    {
+      "user_id": 2,
+      "name": "Bob",
+      "created_at": "2024-01-02T00:00:00"
+    }
+  ]
 }
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,18 +8,21 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
+  font:
+    text: Inter
+    code: JetBrains Mono
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
@@ -81,6 +84,9 @@ extra:
       link: https://github.com/caron14/mcp-bigquery
     - icon: fontawesome/brands/python
       link: https://pypi.org/project/mcp-bigquery/
+
+extra_css:
+  - assets/stylesheets/custom.css
 
 nav:
   - Home: index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/caron14/mcp-bigquery"
-Documentation = "https://github.com/caron14/mcp-bigquery#readme"
+Documentation = "https://caron14.github.io/mcp-bigquery/"
 Repository = "https://github.com/caron14/mcp-bigquery.git"
 Issues = "https://github.com/caron14/mcp-bigquery/issues"
 
@@ -112,11 +112,15 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # imported but unused
 
+[tool.ruff.lint.isort]
+combine-as-imports = true
+
 # isort configuration
 [tool.isort]
 profile = "black"
 line_length = 100
 known_first_party = ["mcp_bigquery"]
+combine_as_imports = true
 
 # mypy configuration
 [tool.mypy]

--- a/src/mcp_bigquery/clients/__init__.py
+++ b/src/mcp_bigquery/clients/__init__.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from google.cloud import bigquery
 
-from .factory import get_bigquery_client as _get_bigquery_client
-from .factory import get_bigquery_client_with_retry as _get_bigquery_client_with_retry
+from .factory import (
+    get_bigquery_client as _get_bigquery_client,
+    get_bigquery_client_with_retry as _get_bigquery_client_with_retry,
+)
 
 __all__ = ["get_bigquery_client", "get_bigquery_client_with_retry"]
 

--- a/src/mcp_bigquery/utils.py
+++ b/src/mcp_bigquery/utils.py
@@ -6,9 +6,11 @@ from typing import cast
 
 from google.api_core.exceptions import GoogleAPIError
 
-from .exceptions import MCPBigQueryError
-from .exceptions import extract_error_location as exc_extract_error_location
-from .exceptions import handle_bigquery_error
+from .exceptions import (
+    MCPBigQueryError,
+    extract_error_location as exc_extract_error_location,
+    handle_bigquery_error,
+)
 from .types import ErrorInfo, ErrorLocation
 
 


### PR DESCRIPTION
This PR provides comprehensive documentation updates for the `v0.7.0` release, refactors the `README.md` structure for improved readability, and introduces visual style tweaks for MkDocs.

#### Key Changes

##### 1. Features Documentation (`docs/`)
- **`docs/index.md` & `docs/usage.md`**: Added detailed explanations, request/response JSON examples, and usage notes for the new completely cost-free `bq_preview_table` tool. Described the safety opt-in requirement (`MCP_BQ_ENABLE_PREVIEW=true`).
- **`docs/module_map.md`**: Updated the module map to version `v0.7.0` and documented the new `schema_explorer/preview.py` module. Adjusted the link for the project TODO tasks to point to `TODO.md`.

##### 2. Visual & Theme Polish (`mkdocs.yml` & `custom.css`)
- **Fonts**: Configured `Inter` for general text and `JetBrains Mono` for code blocks.
- **Color Palette**: Set primary and accent palettes to `custom`.
- **Custom CSS**: Integrated `docs/assets/stylesheets/custom.css` for custom light/dark styling.

##### 3. README.md Restructuring
- Restructured all sections (Configuration, Troubleshooting, Examples, and Project Status) to enhance readability and layout structure.
- Enhanced the troubleshooting guidelines with specific error snippets and clear resolutions.

##### 4. Packaging & Linting Settings (`pyproject.toml`)
- **Documentation URL**: Updated the project's documentation URL from the repository README to the official GitHub Pages URL: `https://caron14.github.io/mcp-bigquery/`.
- **Import Sorting**: Configured `combine-as-imports = true` for both `ruff` and `isort`.

#### Checklist
- [x] MkDocs locally served and validated (correct formatting and links).
- [x] Lint configurations applied.
